### PR TITLE
Enforcement: WSL dbus bug hotfix

### DIFF
--- a/fix-d.sh
+++ b/fix-d.sh
@@ -1,0 +1,9 @@
+sudo service dbus restart
+sudo systemd-machine-id-setup
+sudo dbus-uuidgen --ensure=/etc/machine-id
+export DISPLAY=:0
+export LIBGL_ALWAYS_INDIRECT=1
+bash -l -c "sudo /etc/init.d/dbus start"
+bash -l -c "DISPLAY=:0 dbus-launch --autolaunch $(cat /etc/machine-id) --binary-syntax --close-stderr"
+bash -l -c "DISPLAY=:0 xterm"
+chmod u+s /usr/bin/Xorg 

--- a/start-xfce
+++ b/start-xfce
@@ -1,4 +1,5 @@
 #!/bin/bash
+bash ~/fix-d.sh
 taskkill.exe /IM vcxsrv.exe /T /F
 sleep 2
 /mnt/c/Program\ Files/VcXsrv/vcxsrv.exe  :0 -ac -terminate -lesspointer -multiwindow -clipboard -wgl &


### PR DESCRIPTION
If you find a better way to make dbus behave alike a good boy. Let me know. Much Love.

```

sudo service dbus restart
sudo systemd-machine-id-setup
sudo dbus-uuidgen --ensure=/etc/machine-id
export DISPLAY=:0
export LIBGL_ALWAYS_INDIRECT=1
bash -l -c "sudo /etc/init.d/dbus start"
bash -l -c "DISPLAY=:0 dbus-launch --autolaunch $(cat /etc/machine-id) --binary-syntax --close-stderr"
bash -l -c "DISPLAY=:0 xterm"
chmod u+s /usr/bin/Xorg 

```